### PR TITLE
Errata Clerc Guide Spirituel

### DIFF
--- a/docs/classes/clerc/README.md
+++ b/docs/classes/clerc/README.md
@@ -595,9 +595,9 @@ Vous obtenez les sorts suivants au niveau de clerc indiqué ci-dessous.
 |Niveau de clerc|Sorts|
 |:-:|:-|
 |**1**|[_charme-personne_](/grimoire/charme-personne/)|
-|**2**|[_aide_](/grimoire/aide/)|
+|**2**|[_héroïsme_](/grimoire/heroisme/)|
 |**3**|[_détection des pensées_](/grimoire/detection-des-pensees/)|
-|**4**|[_héroïsme_](/grimoire/heroisme/)|
+|**4**|[_aide_](/grimoire/aide/)|
 |**5**|[_lueur d'espoir_](/grimoire/lueur-d-espoir/)|
 |**6**|[_langues_](/grimoire/langues/)|
 |**7**|[_nimbe de bienfaisance_](/grimoire/nimbe-de-bienfaisance/)|


### PR DESCRIPTION
Correction vue dans l'errata : héroïsme est un sort de niv 1, aide un sort de niv 2. Donc aide ne peut être lancé lorsque le clerc passe niveau 2. Cela parait logique d'inverser les 2 ...