### PR TITLE
Recherche full text avec l'aide de Meilisearch

### DIFF
--- a/contrib/meilisearch/.gitignore
+++ b/contrib/meilisearch/.gitignore
@@ -1,0 +1,2 @@
+venv
+data.ms

--- a/contrib/meilisearch/Makefile
+++ b/contrib/meilisearch/Makefile
@@ -1,0 +1,12 @@
+
+venv:
+	python3 -m venv venv
+	./venv/bin/pip install -U pip wheel
+	./venv/bin/pip install -r requirements.txt
+
+up:
+	docker-compose up -d
+	docker ps
+
+pull:
+	docker-compose pull

--- a/contrib/meilisearch/docker-compose.yml
+++ b/contrib/meilisearch/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+
+version: "3"
+
+services:
+  meilisearch:
+    image: getmeili/meilisearch:latest
+    volumes:
+     - ./data.ms:/data.ms
+    ports:
+     - 7700:7700

--- a/contrib/meilisearch/index.py
+++ b/contrib/meilisearch/index.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+from io import StringIO
+
+import yaml
+from markdown import markdown
+from meilisearch import Client
+
+
+def pages():
+    "return all pages"
+    for readme in Path('.').glob('**/README.md'):
+        if readme == Path("README.md"): # it's the home
+            continue
+        with open(readme, 'r') as file:
+            head = StringIO()
+            body = StringIO()
+            state = None
+            for line in file:
+                if state is None and line == "---\n":
+                    state = "head"
+                    continue
+                if state == "head":
+                    if line == "---\n":
+                        state = "body"
+                        continue
+                    head.write(line)
+                else:
+                    body.write(line)
+            if head.tell() == 0: # empty
+                continue
+            head.seek(0)
+            head = yaml.safe_load(head)
+            body.seek(0)
+            txt = markdown(body.read())
+            yield str(readme), head['title'], txt
+
+
+if __name__ == "__main__":
+    client = Client('http://127.0.0.1:7700')
+    try:
+        idx = client.get_index('pages')
+    except Exception:
+        client.create_index('pages', dict(primaryKey='path'))
+    print(idx)
+    
+    for path, title, body in pages():
+        client.index('pages').add_documents([{
+            'path': path,
+            'title': title,
+            'body': body,
+        }])
+        print(title)

--- a/contrib/meilisearch/requirements.txt
+++ b/contrib/meilisearch/requirements.txt
@@ -1,0 +1,3 @@
+pyyaml
+meilisearch
+markdown


### PR DESCRIPTION
meilisearch.com propose un moteur de recherche dans le genre d'Algolia.

Une indexation naïve, en récupérant le titre, corps de tous les fichiers README.md donne un truc qui me parait crédible et utilisable.

L'intégration dans un frontend statique est prévu : https://docs.meilisearch.com/learn/what_is_meilisearch/sdks.html#front-end-tools

Il est possible d'aller plus loin, comme indexer par chapitre, pour les longues pages, ou utiliser des attributs, comme filtrer le bestiaire par alignement.